### PR TITLE
Key storage fixes

### DIFF
--- a/ionic-core.js
+++ b/ionic-core.js
@@ -37,10 +37,13 @@ angular.module('ionic.service.core', [])
   this.$get = [function() {
     return {
       getId: function() {
-        return this.getValue('app_id');
+        return this.getAppValue('app_id');
       },
       getValue: function(k) {
         return settings[k];
+      },
+      getAppValue: function(k) {
+        return app[k];
       },
       getApiWriteKey: function() {
         return app.api_write_key;
@@ -52,7 +55,7 @@ angular.module('ionic.service.core', [])
         return this.getValue('api_server');
       },
       getApiKey: function() {
-        return this.getValue('api_key');
+        return this.getAppValue('api_key');
       },
       getApiEndpoint: function(service) {
         var app = this.getApp();

--- a/ionic-core.js
+++ b/ionic-core.js
@@ -16,7 +16,7 @@ angular.module('ionic.service.core', [])
 
   var settings = {
     'api_server': 'https://ionic.io',
-    'push_api_server': 'https://push.ionic.io/'
+    'push_api_server': 'https://push.ionic.io'
   };
 
   this.identify = function(opts) {
@@ -37,13 +37,10 @@ angular.module('ionic.service.core', [])
   this.$get = [function() {
     return {
       getId: function() {
-        return this.getAppValue('app_id');
+        return app.app_id;
       },
       getValue: function(k) {
         return settings[k];
-      },
-      getAppValue: function(k) {
-        return app[k];
       },
       getApiWriteKey: function() {
         return app.api_write_key;
@@ -55,7 +52,7 @@ angular.module('ionic.service.core', [])
         return this.getValue('api_server');
       },
       getApiKey: function() {
-        return this.getAppValue('api_key');
+        return app.api_key;
       },
       getApiEndpoint: function(service) {
         var app = this.getApp();


### PR DESCRIPTION
Updated `$ionicApp`'s `getApiKey()` and `getId()` functions to use the `app` object instad of the `settings` object.  They will now return their respective values correctly so long as `identify()` has been called.
