### PR TITLE
Io config

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ionic-service-core",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "homepage": "http://ionic.io",
   "authors": [
     "Eric Bobbitt <eric@drifty.com",

--- a/ionic-core.js
+++ b/ionic-core.js
@@ -1,5 +1,3 @@
-angular.module('ionic.service.core', [])
-
 /**
  * @private
  * Provides a safe interface to store objects in persistent memory
@@ -292,11 +290,12 @@ angular.module('ionic.service.core', [])
 */
 .factory('$ionicUser', [
   '$q',
+  '$ionicCoreSettings'
   '$timeout',
   '$http',
   'persistentStorage',
   '$ionicApp',
-function($q, $timeout, $http, persistentStorage, $ionicApp) {
+function($q, $timeout, $http, $ionicCoreSettings, persistentStorage, $ionicApp) {
       // User object we'll use to store all our user info
 
 
@@ -354,6 +353,12 @@ function($q, $timeout, $http, persistentStorage, $ionicApp) {
 
     _op: function(key, value, type) {
       var u = user.user_id;
+      var appId = '';
+      if ($ionicCoreSettings.get('app_id')) {
+        appId = $ionicCoreSettings.get('app_id')
+      } else {
+        appId = $ionicApp.getId();
+      }
       if(!u) {
         throw new Error("Please call identify with a user_id before calling push");
       }
@@ -361,7 +366,7 @@ function($q, $timeout, $http, persistentStorage, $ionicApp) {
       o['user_id'] = u;
       o[key] = value;
 
-      return $http.post($ionicApp.getApiUrl() + '/api/v1/app/' + $ionicApp.getId() + '/users/' + type, o);
+      return $http.post($ionicApp.getApiUrl() + '/api/v1/app/' + appId + '/users/' + type, o);
     },
     /**
      * Push the given value into the array field identified by the key.
@@ -398,6 +403,12 @@ function($q, $timeout, $http, persistentStorage, $ionicApp) {
       return generateGuid();
     },
     identify: function(userData) {
+      var appId = '';
+      if ($ionicCoreSettings.get('app_id')) {
+        appId = $ionicCoreSettings.get('app_id')
+      } else {
+        appId = $ionicApp.getId();
+      }
       if (!userData.user_id) {
         var msg = 'You must supply a unique user_id field.';
         throw new Error(msg)
@@ -409,9 +420,15 @@ function($q, $timeout, $http, persistentStorage, $ionicApp) {
       // Write the user object to our local storage
       persistentStorage.storeObject(storageKeyName, user);
 
-      return $http.post($ionicApp.getApiUrl() + '/api/v1/app/' + $ionicApp.getId() + '/users/identify', userData);
+      return $http.post($ionicApp.getApiUrl() + '/api/v1/app/' + appId + '/users/identify', userData);
     },
     identifyAnonymous: function() {
+      var appId = '';
+      if ($ionicCoreSettings.get('app_id')) {
+        appId = $ionicCoreSettings.get('app_id')
+      } else {
+        appId = $ionicApp.getId();
+      }
       userData = {};
       userData['user_id'] = generateGuid();
       userData['isAnonymous'] = true;
@@ -422,7 +439,7 @@ function($q, $timeout, $http, persistentStorage, $ionicApp) {
       // Write the user object to our local storage
       persistentStorage.storeObject(storageKeyName, user);
 
-      return $http.post($ionicApp.getApiUrl() + '/api/v1/app/' + $ionicApp.getId() + '/users/identify', userData);
+      return $http.post($ionicApp.getApiUrl() + '/api/v1/app/' + appId + '/users/identify', userData);
     },
     get: function() {
       return user;
@@ -431,6 +448,17 @@ function($q, $timeout, $http, persistentStorage, $ionicApp) {
 }])
 
 // Auto-generated configuration factory
+.factory('$ionicCoreSettings', function() {
+  var settings = {};
+  return {
+    get: function(setting) {
+      if (settings[setting]) {
+        return settings[setting];
+      }
+      return null;
+    }
+  }
+})
 // Auto-generated configuration factory
 
 .run(['$ionicApp', function($ionicApp) {

--- a/ionic-core.js
+++ b/ionic-core.js
@@ -225,25 +225,6 @@ angular.module('ionic.service.core', [])
         return (navigator.userAgent.match(/iPad/i))  == "iPad" ? "ipad" : (navigator.userAgent.match(/iPhone/i))  == "iPhone" ? "iphone" : (navigator.userAgent.match(/Android/i)) == "Android" ? "android" : (navigator.userAgent.match(/BlackBerry/i)) == "BlackBerry" ? "blackberry" : "unknown";
       },
 
-      loadIoXML: function(callback) {
-        var xobj = new XMLHttpRequest();
-
-        xobj.overrideMimeType("application/json");
-        xobj.open('GET', './lib/ionic-service-core/ionic-core-settings.json', true);
-        xobj.onreadystatechange = function () {
-          if (xobj.readyState == 4 && xobj.status == "200") {
-            callback(xobj.responseText);
-          }
-        };
-        xobj.send(null);
-      },
-
-      loadIoConfig: function() {
-        this.loadIoXML(function(resp) {
-          app = JSON.parse(resp);
-        });
-      },
-
       loadCordova: function() {
         if(!_is_cordova_available()) {
           var cordova_script = document.createElement('script');
@@ -282,7 +263,6 @@ angular.module('ionic.service.core', [])
 
       bootstrap: function() {
         this.loadCordova();
-        this.loadIoConfig();
       }
     }
   }];
@@ -449,6 +429,9 @@ function($q, $timeout, $http, persistentStorage, $ionicApp) {
     }
   }
 }])
+
+// Auto-generated configuration factory
+// Auto-generated configuration factory
 
 .run(['$ionicApp', function($ionicApp) {
   console.log('Ionic Core: init');

--- a/ionic-core.js
+++ b/ionic-core.js
@@ -1,3 +1,4 @@
+angular.module('ionic.service.core', [])
 /**
  * @private
  * Provides a safe interface to store objects in persistent memory
@@ -290,7 +291,7 @@
 */
 .factory('$ionicUser', [
   '$q',
-  '$ionicCoreSettings'
+  '$ionicCoreSettings',
   '$timeout',
   '$http',
   'persistentStorage',

--- a/ionic-core.js
+++ b/ionic-core.js
@@ -225,6 +225,25 @@ angular.module('ionic.service.core', [])
         return (navigator.userAgent.match(/iPad/i))  == "iPad" ? "ipad" : (navigator.userAgent.match(/iPhone/i))  == "iPhone" ? "iphone" : (navigator.userAgent.match(/Android/i)) == "Android" ? "android" : (navigator.userAgent.match(/BlackBerry/i)) == "BlackBerry" ? "blackberry" : "unknown";
       },
 
+      loadIoXML: function(callback) {
+        var xobj = new XMLHttpRequest();
+
+        xobj.overrideMimeType("application/json");
+        xobj.open('GET', './lib/ionic-service-core/ionic-core-settings.json', true);
+        xobj.onreadystatechange = function () {
+          if (xobj.readyState == 4 && xobj.status == "200") {
+            callback(xobj.responseText);
+          }
+        };
+        xobj.send(null);
+      },
+
+      loadIoConfig: function() {
+        this.loadIoXML(function(resp) {
+          app = JSON.parse(resp);
+        });
+      },
+
       loadCordova: function() {
         if(!_is_cordova_available()) {
           var cordova_script = document.createElement('script');
@@ -263,6 +282,7 @@ angular.module('ionic.service.core', [])
 
       bootstrap: function() {
         this.loadCordova();
+        this.loadIoConfig();
       }
     }
   }];


### PR DESCRIPTION
Well, as it turns out basically nothing new to this PR, except for a place for the factory to be dropped.  I'm mostly creating it to house the following explanation.

when you run `ionic config set foo bar` or something of the like, it'll spit out the following between the comments.

``` javascript
// Auto-generated configuration factory
.factory('$ionicCoreSettings', function() {
  var settings = {"foo":"bar"};
  return {
    get: function(setting) {
      if (settings[setting]) {
        return settings[setting];
      }
      return null;
    }
  }
})
// Auto-generated configuration factory
```

The comments really only need to be there for clarity, and I could also just look for a place to put the factory without them.

**USAGE:**  So , you'll notice that there's no parsing of the settings in core.  that's because you'll access these via injecting the `$ionicCoreSettings` factory now.  The old way with the `config()` will still work, and this way we can change the individual components to grab those settings straight-up.
